### PR TITLE
Upgrade GitHub Pages actions to latest versions

### DIFF
--- a/.github/workflows/publish_html.yml
+++ b/.github/workflows/publish_html.yml
@@ -53,16 +53,16 @@ jobs:
         run: uv run card_aggregator.py run --output-folder ${{ env.OUTPUT_FOLDER }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ${{ env.OUTPUT_FOLDER }}
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5
 
       - name: Archive card data
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Upgrade all GitHub Pages deployment actions to their latest versions.

## Changes

Updated GitHub Pages actions workflow:
- `actions/configure-pages`: v4 → **v5**
- `actions/upload-pages-artifact`: v3 → **v4**
- `actions/deploy-pages`: v4 → **v4.0.5**

## Verification

All breaking changes verified as non-applicable:

### configure-pages v5
- **Breaking change**: Drops support for Next.js < 13.3.0
- ✅ **Safe**: Not using Next.js (plain HTML/JSON output)

### upload-pages-artifact v4
- **Breaking change**: Excludes dotfiles from artifacts
- ✅ **Safe**: Verified we only output `.html` and `.json` files (no dotfiles)

### deploy-pages v4.0.5
- **Change type**: Patch version only
- ✅ **Safe**: No breaking changes

## Testing

Code review confirmed output files:
- `index.html` - Landing page
- `{aggregator}.html` - 13 HTML report files
- `{aggregator}.json` - 13 JSON data files

**Total: 27 files, all `.html` and `.json` extensions only**

## Related Issues

Closes #2 - Update GitHub Actions to new GitHub Pages deployment strategy

Note: We were already using the modern artifact-based deployment strategy (not the legacy gh-pages branch approach). This PR simply updates the action versions to latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>