### PR TITLE
Add explanatory text support to aggregator HTML pages

### DIFF
--- a/aggregators/base.py
+++ b/aggregators/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List
 
+import markdown
 from jinja2 import Template
 
 logging.basicConfig(level=logging.INFO)
@@ -15,10 +16,17 @@ logger = logging.getLogger(__name__)
 class Aggregator(ABC):
     """Abstract base class for all aggregators."""
 
-    def __init__(self, name: str, display_name: str, description: str = ""):
+    def __init__(
+        self,
+        name: str,
+        display_name: str,
+        description: str = "",
+        explanation: str = "",
+    ):
         self.name = name
         self.display_name = display_name
         self.description = description
+        self.explanation = explanation
         self.column_defs = []
 
     @abstractmethod
@@ -41,11 +49,19 @@ class Aggregator(ABC):
         with json_filepath.open("w", encoding="utf-8") as json_file:
             json.dump(self.get_sorted_data(), json_file)
 
+        # Convert markdown explanation to HTML if present
+        explanation_html = ""
+        if self.explanation:
+            explanation_html = markdown.markdown(
+                self.explanation, extensions=["fenced_code", "tables"]
+            )
+
         # Generate HTML file using template
         html_content = template.render(
             title=self.display_name,
             display_name=self.display_name,
             description=self.description,
+            explanation=explanation_html,
             nav_links=nav_links,
             data_file=json_filename,
             column_defs=self.column_defs,

--- a/aggregators/supercycle_aggregators.py
+++ b/aggregators/supercycle_aggregators.py
@@ -29,9 +29,22 @@ def format_time_difference(days: int) -> str:
 class SupercycleTimeAggregator(Aggregator):
     """Track completion times for card supercycles."""
 
-    def __init__(self, supercycles_file: Path, description: str = ""):
+    def __init__(self, supercycles_file: Path):
         super().__init__(
-            "supercycle_completion_time", "Supercycle Completion Times", description
+            name="supercycle_completion_time",
+            display_name="Supercycle Completion Times",
+            description="Time to complete supercycles",
+            explanation="""
+## What are Supercycles?
+
+Supercycles are groups of related cards printed across multiple sets over time.
+This report tracks how long it took to complete each supercycle from the first
+card to the last card.
+
+**Note:** Times are calculated from the release date of the first card printed
+to the release date of the last card printed. For ongoing supercycles, the time
+shown is from the first card to today's date.
+            """,
         )
         self.supercycles = self.load_supercycles(supercycles_file)
         self.card_dates: Dict[str, date] = {}

--- a/card_aggregator.py
+++ b/card_aggregator.py
@@ -121,8 +121,7 @@ def create_all_aggregators() -> List[Aggregator]:
         ),
         FoilTypesAggregator(description="Foil types by card name"),
         SupercycleTimeAggregator(
-            supercycles_file=MANUAL_DATA_FOLDER / "supercycles.yaml",
-            description="Time to complete supercycles",
+            supercycles_file=MANUAL_DATA_FOLDER / "supercycles.yaml"
         ),
         MaximalTypesWithEffectsAggregator(
             all_creature_types_file=DOWNLOADED_DATA_FOLDER / ALL_CREATURE_TYPES_FILE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "jinja2",
     "beautifulsoup4>=4.13.3",
     "pyyaml>=6.0.2",
+    "markdown>=3.7",
 ]
 
 [tool.uv]

--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -32,6 +32,40 @@
         height: 600px;
         width: 100%;
       }
+
+      .explanation {
+        background-color: #f8f9fa;
+        border-left: 4px solid #007bff;
+        padding: 1rem 1.5rem;
+        margin: 1.5rem 0;
+        border-radius: 4px;
+      }
+
+      .explanation h2 {
+        margin-top: 0;
+        font-size: 1.2rem;
+        color: #333;
+      }
+
+      .explanation p {
+        margin: 0.5rem 0;
+      }
+
+      .explanation ul, .explanation ol {
+        margin: 0.5rem 0;
+        padding-left: 2rem;
+      }
+
+      .explanation code {
+        background-color: #e9ecef;
+        padding: 0.2rem 0.4rem;
+        border-radius: 3px;
+        font-family: monospace;
+      }
+
+      .explanation strong {
+        font-weight: 600;
+      }
     </style>
   </head>
   <body>
@@ -44,6 +78,12 @@
       </select>
       
       <h1>{{ display_name }}</h1>
+
+      {% if explanation %}
+      <div class="explanation">
+        {{ explanation | safe }}
+      </div>
+      {% endif %}
 
       <div id="myGrid" class="ag-theme-quartz-auto-dark"></div>
     </main>

--- a/uv.lock
+++ b/uv.lock
@@ -121,6 +121,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/7dd27d9d863b3376fcf23a5a13cb5d024aed1db46f963f1b5735ae43b3be/markdown-3.10.tar.gz", hash = "sha256:37062d4f2aa4b2b6b32aefb80faa300f82cc790cb949a35b8caede34f2b68c0e", size = 364931 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/81/54e3ce63502cd085a0c556652a4e1b919c45a446bd1e5300e10c44c8c521/markdown-3.10-py3-none-any.whl", hash = "sha256:b5b99d6951e2e4948d939255596523444c0e677c669700b1d17aa4a8a464cb7c", size = 107678 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -187,6 +196,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "ijson" },
     { name = "jinja2" },
+    { name = "markdown" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
@@ -198,6 +208,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.3" },
     { name = "ijson" },
     { name = "jinja2" },
+    { name = "markdown", specifier = ">=3.7" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests" },
     { name = "rich" },


### PR DESCRIPTION
## Summary
- Adds `explanation` field to the Aggregator base class for displaying explanatory text on report pages
- Updates HTML template with styled explanation box that supports markdown formatting
- Adds markdown library dependency for rich text rendering
- Includes example explanation for SupercycleTimeAggregator

## Implementation Details

**Aggregator Base Class** (aggregators/base.py:23):
- Added optional `explanation` parameter to `__init__()`
- Converts markdown to HTML when generating report pages using the `markdown` library
- Supports fenced code blocks and tables extensions

**HTML Template** (templates/base_template.html:36-68):
- Added `.explanation` CSS class with styled box (light background, blue left border)
- Displays explanation between page title and data grid when present
- Supports markdown-rendered HTML (headers, bold, lists, code, etc.)

**Example Usage** (aggregators/supercycle_aggregators.py:32-47):
- SupercycleTimeAggregator now includes explanation about what supercycles are
- Demonstrates how explanations can be hardcoded in aggregator `__init__` methods

## Testing
- Ran full aggregation process successfully
- Verified HTML output includes properly formatted explanation
- Confirmed markdown rendering works correctly

## Dependencies
- Added `markdown>=3.7` to pyproject.toml

## Future Work
This feature provides the foundation for:
- Issue #4: Add note about creature types not yet in comprehensive rules
- Issue #5: Add note about global effects used for maximal types calculation

## Test Plan
- [ ] Review code changes
- [ ] Test locally with `uv run python card_aggregator.py run --serve`
- [ ] Verify explanation appears on Supercycle Completion Times page
- [ ] Check that other pages without explanations still work correctly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)