### PR TITLE
Fix all ty type checker issues

### DIFF
--- a/aggregators/count_aggregators.py
+++ b/aggregators/count_aggregators.py
@@ -91,8 +91,8 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
 
     def process_card(self, card: Dict[str, Any]) -> None:
         collector_number = card.get("collector_number")
-        if collector_number is not None and collector_number.isdigit():
-            key = card.get("set")
+        key = card.get("set")
+        if collector_number is not None and collector_number.isdigit() and key is not None:
             collector_number = int(collector_number)
             self.data[key] = max(self.data[key], collector_number)
 

--- a/aggregators/metadata_aggregators.py
+++ b/aggregators/metadata_aggregators.py
@@ -39,11 +39,13 @@ class CountCardIllustrationsBySetAggregator(Aggregator):
     def process_card(self, card: Dict[str, Any]) -> None:
         set_ = card.get("set")
         name = card.get("name")
+        illustration_id = card.get("illustration_id")
         # Skip cards that lack a set or name to avoid aggregating them under (None, ...) keys.
         if set_ is None or name is None:
             return
         key = (set_, name)
-        self.data[key].add(card.get("illustration_id"))
+        if illustration_id is not None:
+            self.data[key].add(illustration_id)
         # Keep minimal Scryfall data to reduce memory usage
         # Note: Stores first encountered printing's link/image per (set, name).
         # For illustration counting, showing any printing from the set is acceptable.

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -191,7 +191,7 @@ This shows the theoretical maximum types achievable through card combinations!
 - **Type lag:** There may be a delay between when new creature or land types appear on cards and when they're officially added to the comprehensive rules. Cards that grant "all creature types" or "all land types" will only include types that have been updated via the `update-types` command, which fetches the official type lists from the comprehensive rules
         """
         self.global_effects = self.define_global_effects()
-        self.maximal_types: Dict[Tuple[str, ...], Tuple[Dict[str, Any], Set[str]]] = {}
+        self.maximal_types: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         self.column_defs = [
             {"field": "originalTypes", "headerName": "Original Types", "width": 240},
             {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,8 @@ dependencies = [
 
 [tool.uv]
 package = false
+
+[dependency-groups]
+dev = [
+    "ty>=0.0.14",
+]

--- a/type_updater.py
+++ b/type_updater.py
@@ -3,7 +3,7 @@ from typing import Set, Tuple
 from urllib.parse import urljoin
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
 
 
@@ -36,7 +36,13 @@ def fetch_and_parse_types() -> Tuple[Set[str], Set[str]]:
 
     for txt_link in txt_links:
         # Handle relative URLs; assume hrefs are already properly URL-encoded
-        txt_url = urljoin(url, txt_link["href"])
+        # Type check: ensure we have a Tag object with an href attribute
+        if not isinstance(txt_link, Tag):
+            continue
+        href = txt_link.get("href")
+        if href is None or not isinstance(href, str):
+            continue
+        txt_url = urljoin(url, href)
 
         try:
             res = requests.get(txt_url, timeout=60)  # Longer timeout for large file

--- a/uv.lock
+++ b/uv.lock
@@ -203,6 +203,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.3" },
@@ -214,6 +219,9 @@ requires-dist = [
     { name = "rich" },
     { name = "typer" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ty", specifier = ">=0.0.14" }]
 
 [[package]]
 name = "pygments"
@@ -294,6 +302,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb", size = 101569 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/c2/fe97d779f3ef3b15f05c94a2f1e3d21732574ed441687474db9d342a7315/soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9", size = 36186 },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/57/22c3d6bf95c2229120c49ffc2f0da8d9e8823755a1c3194da56e51f1cc31/ty-0.0.14.tar.gz", hash = "sha256:a691010565f59dd7f15cf324cdcd1d9065e010c77a04f887e1ea070ba34a7de2", size = 5036573 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/cb/cc6d1d8de59beb17a41f9a614585f884ec2d95450306c173b3b7cc090d2e/ty-0.0.14-py3-none-linux_armv6l.whl", hash = "sha256:32cf2a7596e693094621d3ae568d7ee16707dce28c34d1762947874060fdddaa", size = 10034228 },
+    { url = "https://files.pythonhosted.org/packages/f3/96/dd42816a2075a8f31542296ae687483a8d047f86a6538dfba573223eaf9a/ty-0.0.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f971bf9805f49ce8c0968ad53e29624d80b970b9eb597b7cbaba25d8a18ce9a2", size = 9939162 },
+    { url = "https://files.pythonhosted.org/packages/ff/b4/73c4859004e0f0a9eead9ecb67021438b2e8e5fdd8d03e7f5aca77623992/ty-0.0.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:45448b9e4806423523268bc15e9208c4f3f2ead7c344f615549d2e2354d6e924", size = 9418661 },
+    { url = "https://files.pythonhosted.org/packages/58/35/839c4551b94613db4afa20ee555dd4f33bfa7352d5da74c5fa416ffa0fd2/ty-0.0.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee94a9b747ff40114085206bdb3205a631ef19a4d3fb89e302a88754cbbae54c", size = 9837872 },
+    { url = "https://files.pythonhosted.org/packages/41/2b/bbecf7e2faa20c04bebd35fc478668953ca50ee5847ce23e08acf20ea119/ty-0.0.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6756715a3c33182e9ab8ffca2bb314d3c99b9c410b171736e145773ee0ae41c3", size = 9848819 },
+    { url = "https://files.pythonhosted.org/packages/be/60/3c0ba0f19c0f647ad9d2b5b5ac68c0f0b4dc899001bd53b3a7537fb247a2/ty-0.0.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:89d0038a2f698ba8b6fec5cf216a4e44e2f95e4a5095a8c0f57fe549f87087c2", size = 10324371 },
+    { url = "https://files.pythonhosted.org/packages/24/32/99d0a0b37d0397b0a989ffc2682493286aa3bc252b24004a6714368c2c3d/ty-0.0.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c64a83a2d669b77f50a4957039ca1450626fb474619f18f6f8a3eb885bf7544", size = 10865898 },
+    { url = "https://files.pythonhosted.org/packages/1a/88/30b583a9e0311bb474269cfa91db53350557ebec09002bfc3fb3fc364e8c/ty-0.0.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:242488bfb547ef080199f6fd81369ab9cb638a778bb161511d091ffd49c12129", size = 10555777 },
+    { url = "https://files.pythonhosted.org/packages/cd/a2/cb53fb6325dcf3d40f2b1d0457a25d55bfbae633c8e337bde8ec01a190eb/ty-0.0.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4790c3866f6c83a4f424fc7d09ebdb225c1f1131647ba8bdc6fcdc28f09ed0ff", size = 10412913 },
+    { url = "https://files.pythonhosted.org/packages/42/8f/f2f5202d725ed1e6a4e5ffaa32b190a1fe70c0b1a2503d38515da4130b4c/ty-0.0.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:950f320437f96d4ea9a2332bbfb5b68f1c1acd269ebfa4c09b6970cc1565bd9d", size = 9837608 },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/59a2a0521640c489dafa2c546ae1f8465f92956fede18660653cce73b4c5/ty-0.0.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4a0ec3ee70d83887f86925bbc1c56f4628bd58a0f47f6f32ddfe04e1f05466df", size = 9884324 },
+    { url = "https://files.pythonhosted.org/packages/03/95/8d2a49880f47b638743212f011088552ecc454dd7a665ddcbdabea25772a/ty-0.0.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1a4e6b6da0c58b34415955279eff754d6206b35af56a18bb70eb519d8d139ef", size = 10033537 },
+    { url = "https://files.pythonhosted.org/packages/e9/40/4523b36f2ce69f92ccf783855a9e0ebbbd0f0bb5cdce6211ee1737159ed3/ty-0.0.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dc04384e874c5de4c5d743369c277c8aa73d1edea3c7fc646b2064b637db4db3", size = 10495910 },
+    { url = "https://files.pythonhosted.org/packages/08/d5/655beb51224d1bfd4f9ddc0bb209659bfe71ff141bcf05c418ab670698f0/ty-0.0.14-py3-none-win32.whl", hash = "sha256:b20e22cf54c66b3e37e87377635da412d9a552c9bf4ad9fc449fed8b2e19dad2", size = 9507626 },
+    { url = "https://files.pythonhosted.org/packages/b6/d9/c569c9961760e20e0a4bc008eeb1415754564304fd53997a371b7cf3f864/ty-0.0.14-py3-none-win_amd64.whl", hash = "sha256:e312ff9475522d1a33186657fe74d1ec98e4a13e016d66f5758a452c90ff6409", size = 10437980 },
+    { url = "https://files.pythonhosted.org/packages/ad/0c/186829654f5bfd9a028f6648e9caeb11271960a61de97484627d24443f91/ty-0.0.14-py3-none-win_arm64.whl", hash = "sha256:b6facdbe9b740cb2c15293a1d178e22ffc600653646452632541d01c36d5e378", size = 9885831 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Installed ty (Astral's fast type checker) as a dev dependency
- Fixed all 13 type issues found by ty
- All type checks now pass with zero diagnostics

## Changes

### aggregators/count_aggregators.py
- Added validation to ensure `card.get("set")` returns a non-None value before using as dictionary key

### aggregators/metadata_aggregators.py
- Added validation to ensure `card.get("illustration_id")` is not None before adding to set

### aggregators/type_aggregators.py
- Fixed incorrect type annotation for `self.maximal_types` in `MaximalTypesWithEffectsAggregator`
- Changed from `Dict[Tuple[str, ...], Tuple[Dict[str, Any], Set[str]]]` to `Dict[Tuple[str, ...], Dict[str, Any]]` to match actual implementation

### type_updater.py
- Added proper type checking for BeautifulSoup Tag objects
- Imported `Tag` type from bs4
- Added `isinstance(txt_link, Tag)` check
- Added `isinstance(href, str)` check to ensure href is a string (not AttributeValueList)

## Testing
Verified with `uv run ty check` - all checks pass.