### PR TITLE
Add ruff formatter and document pre-commit workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,7 @@ supercycles:
 
 ## Dependencies
 
+**Production dependencies:**
 - **typer** - Modern CLI framework with rich terminal output
 - **rich** - Beautiful terminal formatting and progress bars
 - **ijson** - Streaming JSON parser for large files
@@ -178,6 +179,10 @@ supercycles:
 - **jinja2** - Template engine for HTML generation
 - **beautifulsoup4** - HTML parsing for comprehensive rules scraping
 - **pyyaml** - YAML parsing for supercycles data
+
+**Dev dependencies:**
+- **ty** - Astral's extremely fast Python type checker
+- **ruff** - Astral's extremely fast Python linter and formatter
 
 Package management via **uv** (fast pip/poetry replacement).
 
@@ -239,7 +244,9 @@ Workflow file: `.github/workflows/publish_html.yml`
 - Use descriptive variable names
 - Follow existing patterns for consistency
 
-**Committing:**
+**Before committing:**
+- **ALWAYS format code with ruff:** `uv run ruff format .`
+- **ALWAYS typecheck with ty:** `uv run ty check`
 - Write clear commit messages following existing style
 - Reference issue numbers when applicable
 - Test locally with `uv run python card_aggregator.py run --serve`

--- a/aggregators/count_aggregators.py
+++ b/aggregators/count_aggregators.py
@@ -92,7 +92,11 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
     def process_card(self, card: Dict[str, Any]) -> None:
         collector_number = card.get("collector_number")
         key = card.get("set")
-        if collector_number is not None and collector_number.isdigit() and key is not None:
+        if (
+            collector_number is not None
+            and collector_number.isdigit()
+            and key is not None
+        ):
             collector_number = int(collector_number)
             self.data[key] = max(self.data[key], collector_number)
 

--- a/card_aggregator.py
+++ b/card_aggregator.py
@@ -21,7 +21,13 @@ from requests.exceptions import (
 )
 from rich.console import Console
 from rich.panel import Panel
-from rich.progress import DownloadColumn, Progress, SpinnerColumn, TimeElapsedColumn, wrap_file
+from rich.progress import (
+    DownloadColumn,
+    Progress,
+    SpinnerColumn,
+    TimeElapsedColumn,
+    wrap_file,
+)
 from rich.table import Table
 from rich.text import Text
 
@@ -64,8 +70,12 @@ _quiet = False
 
 @app.callback()
 def main(
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Show detailed output")] = False,
-    quiet: Annotated[bool, typer.Option("--quiet", "-q", help="Minimal output")] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Show detailed output")
+    ] = False,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Minimal output")
+    ] = False,
 ):
     """🎴 MTG Card Aggregator - Process Scryfall data and generate interactive reports"""
     global _verbose, _quiet
@@ -210,19 +220,25 @@ def status():
         types_info = f"""[bold]Creature Types:[/bold] {creature_count} types (updated {creature_modified.strftime("%Y-%m-%d")})
 [bold]Land Types:[/bold] {land_count} types (updated {land_modified.strftime("%Y-%m-%d")})"""
     else:
-        types_info = "[yellow]Type files not found. Run 'update-types' command.[/yellow]"
+        types_info = (
+            "[yellow]Type files not found. Run 'update-types' command.[/yellow]"
+        )
 
     console.print(Panel(types_info, title="🏷️  Type Data", border_style="green"))
 
     # Show aggregator count
     agg_count = len(create_all_aggregators())
-    console.print(f"\n[cyan]Available Aggregators:[/cyan] {agg_count} (use '[bold]list[/bold]' command to see details)")
+    console.print(
+        f"\n[cyan]Available Aggregators:[/cyan] {agg_count} (use '[bold]list[/bold]' command to see details)"
+    )
 
 
 @app.command(name="list")
 def list_aggregators():
     """📋 List all available aggregators"""
-    table = Table(title="Available Aggregators", show_header=True, header_style="bold cyan")
+    table = Table(
+        title="Available Aggregators", show_header=True, header_style="bold cyan"
+    )
     table.add_column("Name", style="cyan", no_wrap=True)
     table.add_column("Display Name", style="green")
     table.add_column("Description")
@@ -397,34 +413,47 @@ def download():
 @app.command()
 def all(
     serve: Annotated[bool, typer.Option(help="Start server after processing")] = True,
-    skip_download: Annotated[bool, typer.Option(help="Skip downloading fresh data")] = False,
-    skip_types: Annotated[bool, typer.Option(help="Skip updating creature/land types")] = False,
+    skip_download: Annotated[
+        bool, typer.Option(help="Skip downloading fresh data")
+    ] = False,
+    skip_types: Annotated[
+        bool, typer.Option(help="Skip updating creature/land types")
+    ] = False,
 ):
     """🚀 Run complete workflow: download → update-types → process → serve"""
-    console.print(Panel.fit(
-        "🎴 MTG Card Aggregator - Complete Workflow",
-        border_style="bold blue"
-    ))
+    console.print(
+        Panel.fit(
+            "🎴 MTG Card Aggregator - Complete Workflow", border_style="bold blue"
+        )
+    )
 
     steps_total = 4 - (1 if skip_download else 0) - (1 if skip_types else 0)
     current_step = 1
 
     if not skip_download:
-        console.print(f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Downloading data...")
+        console.print(
+            f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Downloading data..."
+        )
         download()
         current_step += 1
 
     if not skip_types:
-        console.print(f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Updating types...")
+        console.print(
+            f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Updating types..."
+        )
         update_types()
         current_step += 1
 
-    console.print(f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Processing cards...")
+    console.print(
+        f"\n[bold blue]Step {current_step}/{steps_total}:[/bold blue] Processing cards..."
+    )
 
     # Find the latest input file
     input_file = find_latest_default_cards(DOWNLOADED_DATA_FOLDER)
     if input_file is None:
-        console.print("[red]No data file found. Please run with download enabled.[/red]")
+        console.print(
+            "[red]No data file found. Please run with download enabled.[/red]"
+        )
         raise typer.Exit(1)
 
     # Create timestamped output folder
@@ -511,13 +540,17 @@ def run_internal(
         output_folder.mkdir(parents=True, exist_ok=True)
 
     # Show header
-    console.print(Panel.fit(
-        "🎴 MTG Card Aggregator",
-        subtitle="Processing Scryfall data",
-        border_style="blue"
-    ))
+    console.print(
+        Panel.fit(
+            "🎴 MTG Card Aggregator",
+            subtitle="Processing Scryfall data",
+            border_style="blue",
+        )
+    )
     console.print(f"📥 Input:  [cyan]{input_file.name}[/cyan]")
-    console.print(f"📤 Output: [cyan]{output_folder.name if output_folder else 'N/A (dry run)'}[/cyan]")
+    console.print(
+        f"📤 Output: [cyan]{output_folder.name if output_folder else 'N/A (dry run)'}[/cyan]"
+    )
 
     # Create all aggregators
     all_aggregators = create_all_aggregators()
@@ -526,19 +559,25 @@ def run_internal(
     if only:
         aggregators = [a for a in all_aggregators if a.name in only]
         if not aggregators:
-            console.print(f"[yellow]Warning: No aggregators match --only filter. Available: {[a.name for a in all_aggregators]}[/yellow]")
+            console.print(
+                f"[yellow]Warning: No aggregators match --only filter. Available: {[a.name for a in all_aggregators]}[/yellow]"
+            )
             return
     elif exclude:
         aggregators = [a for a in all_aggregators if a.name not in exclude]
         if not aggregators:
-            console.print("[yellow]Warning: All aggregators excluded by --exclude filter[/yellow]")
+            console.print(
+                "[yellow]Warning: All aggregators excluded by --exclude filter[/yellow]"
+            )
             return
     else:
         aggregators = all_aggregators
 
     if dry_run:
         console.print(f"\n[yellow]DRY RUN - No files will be generated[/yellow]\n")
-        table = Table(title="Aggregators to Process", show_header=True, header_style="bold cyan")
+        table = Table(
+            title="Aggregators to Process", show_header=True, header_style="bold cyan"
+        )
         table.add_column("#", style="dim", width=4)
         table.add_column("Name", style="cyan")
         table.add_column("Display Name", style="green")
@@ -547,7 +586,9 @@ def run_internal(
             table.add_row(str(idx), agg.name, agg.display_name)
 
         console.print(table)
-        console.print(f"\n[dim]Total: {len(aggregators)} aggregators would be processed[/dim]")
+        console.print(
+            f"\n[dim]Total: {len(aggregators)} aggregators would be processed[/dim]"
+        )
         return
 
     with wrap_file(
@@ -600,7 +641,9 @@ def run_internal(
 
     # Show summary table
     console.print()
-    table = Table(title="Processing Summary", show_header=True, header_style="bold green")
+    table = Table(
+        title="Processing Summary", show_header=True, header_style="bold green"
+    )
     table.add_column("Aggregator", style="cyan")
     table.add_column("Records", justify="right", style="green")
 
@@ -620,27 +663,42 @@ def run_internal(
 
 @app.command()
 def run(
-    input_file: Annotated[Optional[Path], typer.Option(
-        help="Path to Scryfall JSON file (auto-detects latest if not specified)"
-    )] = None,
-    output_folder: Annotated[Optional[Path], typer.Option(
-        "--output", "-o",
-        help="Output directory (default: timestamped folder in data/output/)"
-    )] = None,
-    serve: Annotated[bool, typer.Option(
-        "--serve", "-s",
-        help="🌐 Start HTTP server and open browser after generation"
-    )] = False,
-    only: Annotated[Optional[List[str]], typer.Option(
-        help="Only run specific aggregators (can specify multiple times)"
-    )] = None,
-    exclude: Annotated[Optional[List[str]], typer.Option(
-        help="Exclude specific aggregators (can specify multiple times)"
-    )] = None,
-    dry_run: Annotated[bool, typer.Option(
-        "--dry-run",
-        help="Show what would be generated without processing"
-    )] = False,
+    input_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            help="Path to Scryfall JSON file (auto-detects latest if not specified)"
+        ),
+    ] = None,
+    output_folder: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-o",
+            help="Output directory (default: timestamped folder in data/output/)",
+        ),
+    ] = None,
+    serve: Annotated[
+        bool,
+        typer.Option(
+            "--serve",
+            "-s",
+            help="🌐 Start HTTP server and open browser after generation",
+        ),
+    ] = False,
+    only: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Only run specific aggregators (can specify multiple times)"),
+    ] = None,
+    exclude: Annotated[
+        Optional[List[str]],
+        typer.Option(help="Exclude specific aggregators (can specify multiple times)"),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run", help="Show what would be generated without processing"
+        ),
+    ] = False,
 ):
     """⚙️  Generate reports from card data"""
     # Use the provided input_file if specified, otherwise find the latest
@@ -681,17 +739,17 @@ def serve_and_open_browser(directory: Path):
     url = f"http://localhost:{port}/index.html"
 
     console.print()
-    console.print(Panel(
-        f"[green]✓[/green] Server running at [link={url}]{url}[/link]\n"
-        f"[yellow]Press Ctrl+C to stop[/yellow]",
-        title="🌐 HTTP Server",
-        border_style="green"
-    ))
+    console.print(
+        Panel(
+            f"[green]✓[/green] Server running at [link={url}]{url}[/link]\n"
+            f"[yellow]Press Ctrl+C to stop[/yellow]",
+            title="🌐 HTTP Server",
+            border_style="green",
+        )
+    )
 
     # Open browser in a separate thread
-    threading.Timer(
-        1.0, lambda: webbrowser.open(url)
-    ).start()
+    threading.Timer(1.0, lambda: webbrowser.open(url)).start()
 
     try:
         # Start server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,6 @@ package = false
 
 [dependency-groups]
 dev = [
+    "ruff>=0.14.14",
     "ty>=0.0.14",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -205,6 +205,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ruff" },
     { name = "ty" },
 ]
 
@@ -221,7 +222,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ty", specifier = ">=0.0.14" }]
+dev = [
+    { name = "ruff", specifier = ">=0.14.14" },
+    { name = "ty", specifier = ">=0.0.14" },
+]
 
 [[package]]
 name = "pygments"
@@ -284,6 +288,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650 },
+    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245 },
+    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273 },
+    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753 },
+    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052 },
+    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637 },
+    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761 },
+    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701 },
+    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455 },
+    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882 },
+    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549 },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416 },
+    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491 },
+    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525 },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626 },
+    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442 },
+    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486 },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Establishes code quality standards by adding ruff formatter and documenting the required pre-commit workflow.

## Changes

### Tools Added
- ✅ **ruff** - Astral's extremely fast Python formatter and linter
  - Same team that makes `uv` and `ty`
  - Replaces black, isort, flake8, and more
  - 10-100x faster than existing tools

### Documentation Updates (`CLAUDE.md`)
- Added **Dev dependencies** section documenting ty and ruff
- Updated **Before committing** section with mandatory checks:
  1. `uv run ruff format .` - Format all code
  2. `uv run ty check` - Typecheck all code

### Code Formatting
- Formatted `aggregators/count_aggregators.py` with ruff
- Formatted `card_aggregator.py` with ruff

## Benefits
- **Consistency**: All code follows the same style
- **Type Safety**: Catches type errors before they reach production
- **Speed**: Both ruff and ty are extremely fast (written in Rust)
- **Documentation**: Clear workflow for contributors and AI assistants

## Pre-commit Workflow
From now on, **all commits must**:
1. Format with ruff: `uv run ruff format .`
2. Typecheck with ty: `uv run ty check`

This is documented in CLAUDE.md for AI assistants to follow automatically.