### PR TITLE
fix: send User-Agent header on Scryfall and rules requests

### DIFF
--- a/card_aggregator.py
+++ b/card_aggregator.py
@@ -44,7 +44,7 @@ from aggregators import (
     SupercycleTimeAggregator,
     TokenOnlyCreatureTypesAggregator,
 )
-from constants import REQUEST_TIMEOUT
+from constants import REQUEST_HEADERS, REQUEST_TIMEOUT
 from type_updater import fetch_and_parse_types
 
 DATA_FOLDER = Path("data").resolve()
@@ -257,7 +257,11 @@ def download():
     logger.info("Downloading bulk data files from Scryfall...")
 
     try:
-        response = requests.get("https://api.scryfall.com/bulk-data", timeout=REQUEST_TIMEOUT)
+        response = requests.get(
+            "https://api.scryfall.com/bulk-data",
+            headers=REQUEST_HEADERS,
+            timeout=REQUEST_TIMEOUT,
+        )
         response.raise_for_status()
         bulk_data_files = response.json()["data"]
     except (ConnectionError, Timeout) as e:
@@ -290,7 +294,9 @@ def download():
     file_path = DOWNLOADED_DATA_FOLDER / file_name
 
     try:
-        response = requests.get(download_url, stream=True, timeout=REQUEST_TIMEOUT)
+        response = requests.get(
+            download_url, headers=REQUEST_HEADERS, stream=True, timeout=REQUEST_TIMEOUT
+        )
         response.raise_for_status()
     except (ConnectionError, Timeout) as e:
         logger.error("Network error while downloading file: {}", e)

--- a/constants.py
+++ b/constants.py
@@ -6,6 +6,16 @@ from datetime import datetime
 REQUEST_TIMEOUT = 30
 RULES_FILE_TIMEOUT = 60
 
+# HTTP request headers. Scryfall (and some other endpoints) reject requests
+# that use the default python-requests User-Agent, returning HTTP 400/403.
+# Scryfall's API guidelines require clients to send a User-Agent and Accept
+# header; see https://scryfall.com/docs/api.
+USER_AGENT = "mtg-card-aggregator/1.0 (+https://github.com/patrickgaskill/mtg)"
+REQUEST_HEADERS = {
+    "User-Agent": USER_AGENT,
+    "Accept": "*/*",
+}
+
 # Card filtering constants
 NON_TRADITIONAL_SET_TYPES = {"memorabilia", "funny"}
 NON_TRADITIONAL_LAYOUTS = {"emblem", "token"}

--- a/constants.py
+++ b/constants.py
@@ -10,7 +10,7 @@ RULES_FILE_TIMEOUT = 60
 # that use the default python-requests User-Agent, returning HTTP 400/403.
 # Scryfall's API guidelines require clients to send a User-Agent and Accept
 # header; see https://scryfall.com/docs/api.
-USER_AGENT = "mtg-card-aggregator/1.0 (+https://github.com/patrickgaskill/mtg)"
+USER_AGENT = "mtg-card-aggregator/1.0"
 REQUEST_HEADERS = {
     "User-Agent": USER_AGENT,
     "Accept": "*/*",

--- a/type_updater.py
+++ b/type_updater.py
@@ -6,14 +6,14 @@ import requests
 from bs4 import BeautifulSoup, Tag
 from requests.exceptions import ConnectionError, HTTPError, RequestException, Timeout
 
-from constants import REQUEST_TIMEOUT, RULES_FILE_TIMEOUT
+from constants import REQUEST_HEADERS, REQUEST_TIMEOUT, RULES_FILE_TIMEOUT
 
 
 def fetch_and_parse_types() -> tuple[set[str], set[str]]:
     url = "https://magic.wizards.com/en/rules"
 
     try:
-        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+        response = requests.get(url, headers=REQUEST_HEADERS, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
     except (ConnectionError, Timeout) as e:
         raise ValueError(f"Network error while fetching rules page: {e}") from None
@@ -47,7 +47,7 @@ def fetch_and_parse_types() -> tuple[set[str], set[str]]:
         txt_url = urljoin(url, href)
 
         try:
-            res = requests.get(txt_url, timeout=RULES_FILE_TIMEOUT)
+            res = requests.get(txt_url, headers=REQUEST_HEADERS, timeout=RULES_FILE_TIMEOUT)
             res.raise_for_status()
             res.encoding = "utf-8"
             rules_text = (


### PR DESCRIPTION
The daily Publish HTML workflow began failing because Scryfall now
rejects requests using the default python-requests User-Agent with
HTTP 400 Bad Request. Add shared REQUEST_HEADERS (User-Agent + Accept)
in constants.py and apply them to all outbound requests in the
download command and type updater.