### PR TITLE
Fix bad-data rows in maximal types and max collector number reports

### DIFF
--- a/aggregators/count_aggregators.py
+++ b/aggregators/count_aggregators.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from typing import Any
 
-from card_utils import get_card_link_data
+from card_utils import get_card_link_data, is_traditional_card
 
 from .base import Aggregator
 
@@ -72,6 +72,12 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
             "max_collector_number_by_set",
             "Maximum Collector Number by Set",
             description,
+            explanation=(
+                "The highest numeric collector number printed in each set. Digital cards and"
+                " non-traditional sets (memorabilia, funny) are excluded because Scryfall uses"
+                " placeholder values as collector numbers there — e.g. Magic Online catalog IDs"
+                " for the prm set and event years for World/Vintage Championship prints."
+            ),
         )
         self.data: dict[str, int] = defaultdict(int)
         self.column_defs = [
@@ -86,6 +92,10 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
         ]
 
     def process_card(self, card: dict[str, Any]) -> None:
+        # Digital cards use Magic Online/Arena catalog IDs as collector numbers, and
+        # memorabilia sets use values like event years — neither is a real number.
+        if card.get("digital") or not is_traditional_card(card):
+            return
         collector_number = card.get("collector_number")
         key = card.get("set")
         if collector_number is not None and collector_number.isdigit() and key is not None:

--- a/aggregators/count_aggregators.py
+++ b/aggregators/count_aggregators.py
@@ -3,7 +3,8 @@
 from collections import defaultdict
 from typing import Any
 
-from card_utils import get_card_link_data, is_traditional_card
+from card_utils import get_card_link_data
+from constants import EXCLUDED_COLLECTOR_NUMBER_SETS
 
 from .base import Aggregator
 
@@ -73,10 +74,10 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
             "Maximum Collector Number by Set",
             description,
             explanation=(
-                "The highest numeric collector number printed in each set. Digital cards and"
-                " non-traditional sets (memorabilia, funny) are excluded because Scryfall uses"
-                " placeholder values as collector numbers there — e.g. Magic Online catalog IDs"
-                " for the prm set and event years for World/Vintage Championship prints."
+                "The highest numeric collector number printed in each set. Sets where Scryfall"
+                " invents collector numbers for cards that don't have real ones — e.g. Magic"
+                " Online catalog IDs for the prm set, or event years for Vintage/Legacy"
+                " Championship prints — are excluded."
             ),
         )
         self.data: dict[str, int] = defaultdict(int)
@@ -92,12 +93,10 @@ class MaxCollectorNumberBySetAggregator(Aggregator):
         ]
 
     def process_card(self, card: dict[str, Any]) -> None:
-        # Digital cards use Magic Online/Arena catalog IDs as collector numbers, and
-        # memorabilia sets use values like event years — neither is a real number.
-        if card.get("digital") or not is_traditional_card(card):
+        key = card.get("set")
+        if key in EXCLUDED_COLLECTOR_NUMBER_SETS:
             return
         collector_number = card.get("collector_number")
-        key = card.get("set")
         if collector_number is not None and collector_number.isdigit() and key is not None:
             collector_number = int(collector_number)
             self.data[key] = max(self.data[key], collector_number)

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -15,6 +15,10 @@ from card_utils import (
 
 from .base import Aggregator
 
+# Card types whose subtypes are creature or land types, and therefore verifiable
+# against the comprehensive rules type lists.
+SUBTYPE_VERIFIABLE_TYPES = {"Creature", "Kindred", "Tribal", "Land"}
+
 
 class MaximalPrintedTypesAggregator(Aggregator):
     """Find cards with maximal printed type combinations."""
@@ -32,10 +36,13 @@ class MaximalPrintedTypesAggregator(Aggregator):
             explanation=(
                 "Cards whose printed types form a maximum set — no other card's printed types"
                 " are a strict superset. Changelings count as having all creature types and"
-                " Planar Nexus counts as having all nonbasic land types."
+                " Planar Nexus counts as having all nonbasic land types. Cards with creature or"
+                " land subtypes that are not yet in the comprehensive rules (e.g. from newly"
+                " previewed sets) are excluded until the rules are updated."
             ),
         )
         self.maximal_types: dict[tuple[str, ...], dict[str, Any]] = {}
+        self._unknown_subtypes_seen: set[str] = set()
         self._types_field = "types"
         self.column_defs = [
             {"field": "types", "headerName": "Types", "width": 300},
@@ -82,6 +89,18 @@ class MaximalPrintedTypesAggregator(Aggregator):
         if "Token" in card_types or "Emblem" in card_types:
             return
 
+        unknown_subtypes = self._get_unknown_subtypes(face, card_types)
+        if unknown_subtypes:
+            for subtype in sorted(unknown_subtypes):
+                if subtype not in self._unknown_subtypes_seen:
+                    self._unknown_subtypes_seen.add(subtype)
+                    self.warnings.append(
+                        f"Skipping cards with subtype '{subtype}'"
+                        f" (e.g. {face.get('name', 'Unknown')}):"
+                        " not yet in the comprehensive rules type lists"
+                    )
+            return
+
         if is_all_creature_types(face):
             card_types |= self.all_creature_types
 
@@ -111,6 +130,26 @@ class MaximalPrintedTypesAggregator(Aggregator):
             for key in keys_to_remove:
                 del self.maximal_types[key]
             self.maximal_types[type_key] = parent_card
+
+    def _get_unknown_subtypes(self, face: dict[str, Any], card_types: set[str]) -> set[str]:
+        """
+        Find creature/land subtypes on a face that aren't in the comprehensive rules yet.
+
+        Scryfall publishes card data for newly previewed sets before the comprehensive
+        rules (and thus the type lists) are updated, which would otherwise produce
+        spurious maximal rows. Only creature and land subtypes can be verified, so
+        subtypes of other card types (spells, artifacts, etc.) are not checked.
+        """
+        if not self.all_creature_types or not self.all_land_types:
+            # Type lists failed to load; load_types already warned.
+            return set()
+        if not card_types & SUBTYPE_VERIFIABLE_TYPES:
+            return set()
+        type_line = face.get("type_line", "")
+        if "—" not in type_line:
+            return set()
+        subtypes = extract_types({"type_line": type_line.split("—", 1)[1]})
+        return subtypes - self.all_creature_types - self.all_land_types
 
     def _modify_types(self, card_types: set[str]) -> set[str]:
         """Hook for subclasses to modify types before maximality check."""
@@ -147,7 +186,9 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
         self.explanation = (
             "Cards that reach the maximum number of types when global effects from other cards"
             " in play are applied (e.g., In Bolas's Clutches grants Legendary, Maskwood Nexus"
-            " grants all creature types, Omo grants all land and creature types)."
+            " grants all creature types, Omo grants all land and creature types). Cards with"
+            " creature or land subtypes that are not yet in the comprehensive rules (e.g. from"
+            " newly previewed sets) are excluded until the rules are updated."
         )
         self._types_field = "originalTypes"
         self.global_effects = self._define_global_effects()

--- a/constants.py
+++ b/constants.py
@@ -20,9 +20,16 @@ REQUEST_HEADERS = {
 # real ones printed — e.g. Magic Online catalog IDs or event years. These are
 # excluded from the max-collector-number report.
 EXCLUDED_COLLECTOR_NUMBER_SETS = {
-    "prm",  # Magic Online Promos — Magic Online catalog IDs
-    "ovnt",  # Vintage Championship — event years
+    "ana",  # Arena New Player Experience — Arena IDs
     "olgc",  # Legacy Championship — event years
+    "ovnt",  # Vintage Championship — event years
+    "pgpx",  # Grand Prix Promos — event years
+    "pnat",  # Nationals Promos — event years
+    "ppro",  # Pro Tour Promos — event years
+    "prm",  # Magic Online Promos — Magic Online catalog IDs
+    "pwor",  # World Championship Promos — event years
+    "pz2",  # Treasure Chest — Magic Online catalog IDs
+    "wmc",  # World Magic Cup Qualifiers — event years
 }
 
 # Card filtering constants

--- a/constants.py
+++ b/constants.py
@@ -16,6 +16,15 @@ REQUEST_HEADERS = {
     "Accept": "*/*",
 }
 
+# Sets where Scryfall invents collector numbers because the cards don't have
+# real ones printed — e.g. Magic Online catalog IDs or event years. These are
+# excluded from the max-collector-number report.
+EXCLUDED_COLLECTOR_NUMBER_SETS = {
+    "prm",  # Magic Online Promos — Magic Online catalog IDs
+    "ovnt",  # Vintage Championship — event years
+    "olgc",  # Legacy Championship — event years
+}
+
 # Card filtering constants
 NON_TRADITIONAL_SET_TYPES = {"memorabilia", "funny"}
 NON_TRADITIONAL_LAYOUTS = {"emblem", "token"}

--- a/tests/test_count_aggregators.py
+++ b/tests/test_count_aggregators.py
@@ -1,0 +1,51 @@
+"""Tests for the counting aggregators."""
+
+from aggregators.count_aggregators import MaxCollectorNumberBySetAggregator
+
+
+def make_card(**overrides):
+    base = {
+        "name": "Test Card",
+        "set": "tst",
+        "set_type": "expansion",
+        "layout": "normal",
+        "border_color": "black",
+        "collector_number": "42",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestMaxCollectorNumberBySetAggregator:
+    def test_tracks_max_number_per_set(self):
+        aggregator = MaxCollectorNumberBySetAggregator()
+        aggregator.process_card(make_card(collector_number="42"))
+        aggregator.process_card(make_card(collector_number="7"))
+        aggregator.process_card(make_card(collector_number="300", set="oth"))
+        assert aggregator.get_sorted_data() == [
+            {"set": "oth", "maxNumber": 300},
+            {"set": "tst", "maxNumber": 42},
+        ]
+
+    def test_ignores_non_numeric_collector_numbers(self):
+        aggregator = MaxCollectorNumberBySetAggregator()
+        aggregator.process_card(make_card(collector_number="123a"))
+        assert aggregator.get_sorted_data() == []
+
+    def test_skips_digital_cards(self):
+        # Scryfall uses Magic Online catalog IDs as collector numbers for
+        # digital sets like prm, which aren't real collector numbers.
+        aggregator = MaxCollectorNumberBySetAggregator()
+        aggregator.process_card(
+            make_card(set="prm", set_type="promo", collector_number="65961", digital=True)
+        )
+        assert aggregator.get_sorted_data() == []
+
+    def test_skips_non_traditional_sets(self):
+        # Memorabilia prints like Vintage Championship use event years as
+        # collector numbers.
+        aggregator = MaxCollectorNumberBySetAggregator()
+        aggregator.process_card(
+            make_card(set="ovnt", set_type="memorabilia", collector_number="2018")
+        )
+        assert aggregator.get_sorted_data() == []

--- a/tests/test_count_aggregators.py
+++ b/tests/test_count_aggregators.py
@@ -32,20 +32,18 @@ class TestMaxCollectorNumberBySetAggregator:
         aggregator.process_card(make_card(collector_number="123a"))
         assert aggregator.get_sorted_data() == []
 
-    def test_skips_digital_cards(self):
-        # Scryfall uses Magic Online catalog IDs as collector numbers for
-        # digital sets like prm, which aren't real collector numbers.
+    def test_skips_sets_with_invented_collector_numbers(self):
+        # Scryfall invents collector numbers for some sets — e.g. Magic Online
+        # catalog IDs for prm, event years for Vintage Championship prints.
         aggregator = MaxCollectorNumberBySetAggregator()
-        aggregator.process_card(
-            make_card(set="prm", set_type="promo", collector_number="65961", digital=True)
-        )
+        aggregator.process_card(make_card(set="prm", collector_number="65961"))
+        aggregator.process_card(make_card(set="ovnt", collector_number="2018"))
         assert aggregator.get_sorted_data() == []
 
-    def test_skips_non_traditional_sets(self):
-        # Memorabilia prints like Vintage Championship use event years as
-        # collector numbers.
+    def test_counts_silver_border_and_funny_sets(self):
+        # Un-set cards have real printed collector numbers.
         aggregator = MaxCollectorNumberBySetAggregator()
         aggregator.process_card(
-            make_card(set="ovnt", set_type="memorabilia", collector_number="2018")
+            make_card(set="ust", set_type="funny", border_color="silver", collector_number="216")
         )
-        assert aggregator.get_sorted_data() == []
+        assert aggregator.get_sorted_data() == [{"set": "ust", "maxNumber": 216}]

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -1,0 +1,124 @@
+"""Tests for the maximal types aggregators."""
+
+import pytest
+
+from aggregators.type_aggregators import (
+    MaximalPrintedTypesAggregator,
+    MaximalTypesWithEffectsAggregator,
+)
+
+CREATURE_TYPES = ["Bear", "Doctor", "Human", "Illusion", "Time Lord", "Wizard"]
+LAND_TYPES = ["Forest", "Gate", "Island", "Mountain", "Plains", "Swamp"]
+
+
+@pytest.fixture
+def type_files(temp_dir):
+    """Write known creature and land type files, returning their paths."""
+    creature_file = temp_dir / "all_creature_types.txt"
+    creature_file.write_text("".join(f"{t}\n" for t in CREATURE_TYPES))
+    land_file = temp_dir / "all_land_types.txt"
+    land_file.write_text("".join(f"{t}\n" for t in LAND_TYPES))
+    return creature_file, land_file
+
+
+@pytest.fixture
+def aggregator(type_files):
+    return MaximalPrintedTypesAggregator(*type_files)
+
+
+def make_card(**overrides):
+    base = {
+        "name": "Test Card",
+        "type_line": "Creature — Human Wizard",
+        "set_type": "expansion",
+        "layout": "normal",
+        "border_color": "black",
+        "set": "tst",
+        "collector_number": "1",
+        "released_at": "2020-01-01",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestUnknownSubtypeHandling:
+    def test_known_subtypes_are_processed(self, aggregator):
+        aggregator.process_card(make_card())
+        assert len(aggregator.maximal_types) == 1
+
+    def test_unknown_creature_subtype_is_skipped(self, aggregator):
+        aggregator.process_card(make_card(name="New Card", type_line="Creature — Human Fremen"))
+        assert len(aggregator.maximal_types) == 0
+        assert any("Fremen" in w for w in aggregator.warnings)
+        assert any("New Card" in w for w in aggregator.warnings)
+
+    def test_unknown_land_subtype_is_skipped(self, aggregator):
+        aggregator.process_card(make_card(type_line="Land — Sphere"))
+        assert len(aggregator.maximal_types) == 0
+        assert any("Sphere" in w for w in aggregator.warnings)
+
+    def test_unknown_subtype_warned_once(self, aggregator):
+        aggregator.process_card(make_card(type_line="Creature — Fremen"))
+        aggregator.process_card(make_card(type_line="Creature — Fremen Wizard"))
+        assert sum("Fremen" in w for w in aggregator.warnings) == 1
+
+    def test_kindred_subtypes_are_checked(self, aggregator):
+        aggregator.process_card(make_card(type_line="Kindred Instant — Fremen"))
+        assert len(aggregator.maximal_types) == 0
+
+    def test_land_creature_with_known_types_is_processed(self, aggregator):
+        aggregator.process_card(make_card(type_line="Land Creature — Forest Bear"))
+        assert len(aggregator.maximal_types) == 1
+
+    def test_time_lord_subtype_is_recognized(self, aggregator):
+        aggregator.process_card(make_card(type_line="Creature — Time Lord Doctor"))
+        assert len(aggregator.maximal_types) == 1
+
+    def test_non_creature_subtypes_are_not_checked(self, aggregator):
+        # Aura is not in the creature or land type lists, but spell subtypes
+        # can't be verified against the comprehensive rules type lists.
+        aggregator.process_card(make_card(type_line="Enchantment — Aura"))
+        assert len(aggregator.maximal_types) == 1
+
+    def test_subtypeless_type_line_is_processed(self, aggregator):
+        aggregator.process_card(make_card(type_line="Creature"))
+        assert len(aggregator.maximal_types) == 1
+
+    def test_unknown_subtype_on_card_face_is_skipped(self, aggregator):
+        card = make_card(
+            type_line="Creature — Human // Creature — Human Fremen",
+            card_faces=[
+                {"name": "Front", "type_line": "Creature — Human"},
+                {"name": "Back", "type_line": "Creature — Human Fremen"},
+            ],
+        )
+        aggregator.process_card(card)
+        assert list(aggregator.maximal_types) == [("Creature", "Human")]
+
+    def test_check_disabled_when_type_files_missing(self, temp_dir):
+        aggregator = MaximalPrintedTypesAggregator(
+            temp_dir / "missing_creatures.txt", temp_dir / "missing_lands.txt"
+        )
+        aggregator.process_card(make_card(type_line="Creature — Human Fremen"))
+        assert len(aggregator.maximal_types) == 1
+
+    def test_changeling_with_unknown_subtype_is_skipped(self, aggregator, type_files):
+        aggregator.process_card(make_card(type_line="Creature — Fremen", keywords=["Changeling"]))
+        assert len(aggregator.maximal_types) == 0
+
+    def test_effects_aggregator_also_skips_unknown_subtypes(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Creature — Fremen"))
+        assert len(aggregator.maximal_types) == 0
+
+
+class TestMaximality:
+    def test_subset_is_replaced_by_superset(self, aggregator):
+        aggregator.process_card(make_card(type_line="Creature — Human"))
+        aggregator.process_card(make_card(type_line="Creature — Human Wizard"))
+        assert list(aggregator.maximal_types) == [("Creature", "Human", "Wizard")]
+
+    def test_incomparable_sets_are_both_kept(self, aggregator):
+        aggregator.process_card(make_card(type_line="Creature — Human Wizard"))
+        aggregator.process_card(make_card(type_line="Creature — Bear"))
+        assert len(aggregator.maximal_types) == 2


### PR DESCRIPTION
## Summary

Fixes two sources of bogus rows in the generated reports:

**Maximal types aggregators** — Scryfall publishes card data for newly previewed sets before the comprehensive rules (and thus the creature/land type lists) are updated, so new subtypes produced spurious maximal rows. Faces whose creature or land subtypes aren't in the loaded type lists are now skipped until the rules catch up, with a warning logged once per unknown subtype. The check is disabled if the type lists failed to load, and only creature/land subtypes are checked since other subtypes can't be verified against the rules lists. Both `MaximalPrintedTypesAggregator` and `MaximalTypesWithEffectsAggregator` get the fix.

**Max collector number by set** — some sets had rows built from collector numbers Scryfall invents for cards that don't have real ones (Magic Online catalog IDs for `prm`/`pz2`, Arena IDs for `ana`, event years for tournament promo sets). These sets are now excluded via an explicit `EXCLUDED_COLLECTOR_NUMBER_SETS` blocklist in `constants.py` (`ana`, `olgc`, `ovnt`, `pgpx`, `pnat`, `ppro`, `prm`, `pwor`, `pz2`, `wmc`), easy to extend if more turn up. Silver-border and other funny sets still count, since their printed collector numbers are real.

## Testing

- New `tests/test_type_aggregators.py` covering unknown-subtype skipping (card faces, Time Lord, land creatures, Kindred, missing type files fallback, warning dedup) and maximality behavior
- New `tests/test_count_aggregators.py` covering the blocklist and that silver-border/funny sets are still counted
- `uv run pytest` — 102 passed; `ruff format`/`ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PUhP4hSHAQcwSQHwJFquD

---
_Generated by [Claude Code](https://claude.ai/code/session_017PUhP4hSHAQcwSQHwJFquD)_