### PR TITLE
feat: add Ashaya, Ragost, Senator Peacock, and Armed with Proof to maximal types global effects

### DIFF
--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -186,7 +186,8 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
         self.explanation = (
             "Cards that reach the maximum number of types when global effects from other cards"
             " in play are applied (e.g., In Bolas's Clutches grants Legendary, Maskwood Nexus"
-            " grants all creature types, Omo grants all land and creature types). Cards with"
+            " grants all creature types, Ashaya makes creatures Forest lands, Omo grants all"
+            " land and creature types). Cards with"
             " creature or land subtypes that are not yet in the comprehensive rules (e.g. from"
             " newly previewed sets) are excluded until the rules are updated."
         )
@@ -242,6 +243,9 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
                 {"Creature", "Land", "Saproling", "Forest"}
             )
             if "Forest" in card_types or "Saproling" in card_types
+            else card_types,
+            "Ashaya, Soul of the Wild": lambda card_types: card_types.union({"Land", "Forest"})
+            if "Creature" in card_types
             else card_types,
             "Prismatic Omen": lambda card_types: card_types.union(BASIC_LAND_TYPES)
             if "Land" in card_types

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -239,6 +239,9 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
             "Senator Peacock": lambda card_types: card_types.union({"Clue"})
             if "Artifact" in card_types
             else card_types,
+            "Armed with Proof": lambda card_types: card_types.union({"Equipment"})
+            if "Clue" in card_types
+            else card_types,
             "March of the Machines": lambda card_types: card_types.union({"Creature"})
             if "Artifact" in card_types and "Creature" not in card_types
             else card_types,

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -233,6 +233,9 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
             "Mycosynth Lattice": lambda card_types: card_types.union({"Artifact"})
             if is_permanent({"type_line": " ".join(card_types)})
             else card_types,
+            "Ragost, Deft Gastronaut": lambda card_types: card_types.union({"Food"})
+            if "Artifact" in card_types
+            else card_types,
             "March of the Machines": lambda card_types: card_types.union({"Creature"})
             if "Artifact" in card_types and "Creature" not in card_types
             else card_types,

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -236,6 +236,9 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
             "Ragost, Deft Gastronaut": lambda card_types: card_types.union({"Food"})
             if "Artifact" in card_types
             else card_types,
+            "Senator Peacock": lambda card_types: card_types.union({"Clue"})
+            if "Artifact" in card_types
+            else card_types,
             "March of the Machines": lambda card_types: card_types.union({"Creature"})
             if "Artifact" in card_types and "Creature" not in card_types
             else card_types,

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -112,6 +112,28 @@ class TestUnknownSubtypeHandling:
         assert len(aggregator.maximal_types) == 0
 
 
+class TestGlobalEffects:
+    def test_ashaya_makes_creatures_forest_lands(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Creature — Bear"))
+        (key,) = aggregator.maximal_types
+        assert {"Land", "Forest"}.issubset(key)
+
+    def test_ashaya_chains_into_land_type_effects(self, type_files):
+        # Ashaya grants Land before Prismatic Omen and Omo apply, so a
+        # creature ends up with every land type.
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Creature — Bear"))
+        (key,) = aggregator.maximal_types
+        assert set(LAND_TYPES).issubset(key)
+
+    def test_ashaya_ignores_noncreatures(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Instant"))
+        (key,) = aggregator.maximal_types
+        assert "Land" not in key
+
+
 class TestMaximality:
     def test_subset_is_replaced_by_superset(self, aggregator):
         aggregator.process_card(make_card(type_line="Creature — Human"))

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -147,6 +147,14 @@ class TestGlobalEffects:
         (key,) = aggregator.maximal_types
         assert "Clue" in key
 
+    def test_armed_with_proof_chains_clues_into_equipment(self, type_files):
+        # Senator Peacock makes artifacts Clues, then Armed with Proof
+        # makes Clues Equipment.
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Artifact"))
+        (key,) = aggregator.maximal_types
+        assert "Equipment" in key
+
     def test_ashaya_ignores_noncreatures(self, type_files):
         aggregator = MaximalTypesWithEffectsAggregator(*type_files)
         aggregator.process_card(make_card(type_line="Instant"))

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -141,6 +141,12 @@ class TestGlobalEffects:
         (key,) = aggregator.maximal_types
         assert "Food" in key
 
+    def test_senator_peacock_makes_artifacts_clues(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Artifact"))
+        (key,) = aggregator.maximal_types
+        assert "Clue" in key
+
     def test_ashaya_ignores_noncreatures(self, type_files):
         aggregator = MaximalTypesWithEffectsAggregator(*type_files)
         aggregator.process_card(make_card(type_line="Instant"))

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -127,6 +127,20 @@ class TestGlobalEffects:
         (key,) = aggregator.maximal_types
         assert set(LAND_TYPES).issubset(key)
 
+    def test_ragost_makes_artifacts_foods(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Artifact"))
+        (key,) = aggregator.maximal_types
+        assert "Food" in key
+
+    def test_ragost_applies_after_mycosynth_lattice(self, type_files):
+        # Every permanent becomes an artifact via Mycosynth Lattice, so
+        # Ragost grants Food to non-artifact permanents too.
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Enchantment"))
+        (key,) = aggregator.maximal_types
+        assert "Food" in key
+
     def test_ashaya_ignores_noncreatures(self, type_files):
         aggregator = MaximalTypesWithEffectsAggregator(*type_files)
         aggregator.process_card(make_card(type_line="Instant"))


### PR DESCRIPTION
## Summary

Adds four cards to the global effects list in the Maximal Types with Global Effects report:

- **Ashaya, Soul of the Wild** — creatures become Forest lands, ordered before Prismatic Omen and Omo so creatures chain into every land type
- **Ragost, Deft Gastronaut** — artifacts gain the Food type
- **Senator Peacock** — artifacts gain the Clue type
- **Armed with Proof** — Clues gain the Equipment type, ordered after Senator Peacock so artifacts chain Artifact → Clue → Equipment

All four are ordered so grants compound through the existing chain (e.g. Mycosynth Lattice makes every permanent an artifact, which now picks up Food, Clue, and Equipment).

Also considered and intentionally excluded:

- **Applied Geometry** — only retypes a token copy it creates, and tokens are excluded from the report
- **Tangletrove Kelp** — grants Creature + Plant to Clues, fully redundant with March of the Machines + Maskwood Nexus
- **Bello, Bard of the Brambles** — grants Creature + Elemental to artifacts/enchantments, likewise redundant
- **Dermotaxi** (from the predecessor magictypes repo) — copy-based effect, left out pending a decision on copy semantics

## Testing

- 7 new tests covering each effect's direct grant and the chained interactions
- `uv run pytest` — 109 passed
- `uv run ruff format .` / `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v)_