### PR TITLE
feat: count Grist as an Insect creature and minimize the global effects list

### DIFF
--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -224,7 +224,13 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
         return card_types
 
     def _define_global_effects(self):
-        """Define global effects that modify card types."""
+        """
+        Define global effects that modify card types.
+
+        Keep this list minimal: an effect belongs here only if it grants a type
+        no combination of the other effects can reach (e.g. Life and Limb and
+        Prismatic Omen were removed once Ashaya and Omo covered their grants).
+        """
         return {
             "In Bolas's Clutches": lambda card_types: card_types.union({"Legendary"})
             if is_permanent({"type_line": " ".join(card_types)})
@@ -253,16 +259,8 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
             "Maskwood Nexus": lambda card_types: card_types.union(self.all_creature_types)
             if "Creature" in card_types
             else card_types,
-            "Life and Limb": lambda card_types: card_types.union(
-                {"Creature", "Land", "Saproling", "Forest"}
-            )
-            if "Forest" in card_types or "Saproling" in card_types
-            else card_types,
             "Ashaya, Soul of the Wild": lambda card_types: card_types.union({"Land", "Forest"})
             if "Creature" in card_types
-            else card_types,
-            "Prismatic Omen": lambda card_types: card_types.union(BASIC_LAND_TYPES)
-            if "Land" in card_types
             else card_types,
             "Omo, Queen of Vesuva": self._omo_effect,
         }

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -35,8 +35,9 @@ class MaximalPrintedTypesAggregator(Aggregator):
             description,
             explanation=(
                 "Cards whose printed types form a maximum set — no other card's printed types"
-                " are a strict superset. Changelings count as having all creature types and"
-                " Planar Nexus counts as having all nonbasic land types. Cards with creature or"
+                " are a strict superset. Changelings count as having all creature types,"
+                " Planar Nexus counts as having all nonbasic land types, and Grist counts as"
+                " an Insect creature. Cards with creature or"
                 " land subtypes that are not yet in the comprehensive rules (e.g. from newly"
                 " previewed sets) are excluded until the rules are updated."
             ),
@@ -106,6 +107,10 @@ class MaximalPrintedTypesAggregator(Aggregator):
 
         if face.get("name") == "Planar Nexus":
             card_types |= self.nonbasic_land_types
+
+        # Grist is a 1/1 Insect creature in every zone except the battlefield.
+        if face.get("name") == "Grist, the Hunger Tide":
+            card_types |= {"Creature", "Insect"}
 
         card_types = self._modify_types(card_types)
 

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -120,8 +120,8 @@ class TestGlobalEffects:
         assert {"Land", "Forest"}.issubset(key)
 
     def test_ashaya_chains_into_land_type_effects(self, type_files):
-        # Ashaya grants Land before Prismatic Omen and Omo apply, so a
-        # creature ends up with every land type.
+        # Ashaya grants Land before Omo applies, so a creature ends up
+        # with every land type.
         aggregator = MaximalTypesWithEffectsAggregator(*type_files)
         aggregator.process_card(make_card(type_line="Creature — Bear"))
         (key,) = aggregator.maximal_types

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -162,6 +162,25 @@ class TestGlobalEffects:
         assert "Land" not in key
 
 
+class TestNameBasedTypes:
+    def test_grist_counts_as_insect_creature(self, aggregator):
+        aggregator.process_card(
+            make_card(
+                name="Grist, the Hunger Tide",
+                type_line="Legendary Planeswalker — Grist",
+            )
+        )
+        assert list(aggregator.maximal_types) == [
+            ("Creature", "Grist", "Insect", "Legendary", "Planeswalker")
+        ]
+
+    def test_other_planeswalkers_are_unchanged(self, aggregator):
+        aggregator.process_card(
+            make_card(name="Jace Beleren", type_line="Legendary Planeswalker — Jace")
+        )
+        assert list(aggregator.maximal_types) == [("Jace", "Legendary", "Planeswalker")]
+
+
 class TestMaximality:
     def test_subset_is_replaced_by_superset(self, aggregator):
         aggregator.process_card(make_card(type_line="Creature — Human"))


### PR DESCRIPTION
## Summary

Two changes to the maximal types reports:

- **Grist, the Hunger Tide** now counts as an Insect creature in addition to its printed planeswalker types, handled by name in `process_single_face` like Planar Nexus. Its characteristic-defining ability makes it a 1/1 Insect creature in every zone except the battlefield. This mainly affects the Maximal Printed Types report, where its row becomes Creature + Grist + Insect + Legendary + Planeswalker.
- **Removed Life and Limb and Prismatic Omen** from the global effects list, reducing it to the minimum necessary. Both are fully covered by the remaining chain: Mycosynth Lattice + March of the Machines grant Creature, Maskwood Nexus grants Saproling, Ashaya grants Land and Forest, and Omo grants every land type (a strict superset of Prismatic Omen's basics). Removing Life and Limb also fixes an overgrant to nonpermanent Saproling cards (e.g. Sprout Swarm, a Tribal Instant that can never be on the battlefield to receive it). A docstring on `_define_global_effects` now records the minimality policy: an effect belongs only if it grants a type no combination of the others can reach.

Cards evaluated and excluded as redundant or out of scope: Toph, the First Metalbender; Dune Chanter; Vihaan, Goldwaker; Dan Lewis; Encroaching Mycosynth; Tangletrove Kelp.

## Testing

- New tests for Grist's type addition and a guard that other planeswalkers are unchanged
- `uv run pytest` — 111 passed
- `uv run ruff format .` / `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v)_