### PR TITLE
fix: filter bad-data types and Mystery Booster playtest cards

### DIFF
--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -19,6 +19,11 @@ from .base import Aggregator
 # against the comprehensive rules type lists.
 SUBTYPE_VERIFIABLE_TYPES = {"Creature", "Kindred", "Tribal", "Land"}
 
+# Types marking non-playable objects: Tokens and Emblems aren't cards, while
+# "Card" and "Stickers" are Scryfall placeholders for substitute cards, art
+# series, sticker sheets, and similar objects.
+SKIPPED_TYPES = {"Token", "Emblem", "Card", "Stickers"}
+
 
 class MaximalPrintedTypesAggregator(Aggregator):
     """Find cards with maximal printed type combinations."""
@@ -87,9 +92,7 @@ class MaximalPrintedTypesAggregator(Aggregator):
         """Process a single face of a card."""
         card_types = extract_types(face)
 
-        # Scryfall uses "Card" as a placeholder type on substitute cards,
-        # art series, and similar non-playable objects.
-        if "Token" in card_types or "Emblem" in card_types or "Card" in card_types:
+        if card_types & SKIPPED_TYPES:
             return
 
         unknown_subtypes = self._get_unknown_subtypes(face, card_types)

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -87,7 +87,9 @@ class MaximalPrintedTypesAggregator(Aggregator):
         """Process a single face of a card."""
         card_types = extract_types(face)
 
-        if "Token" in card_types or "Emblem" in card_types:
+        # Scryfall uses "Card" as a placeholder type on substitute cards,
+        # art series, and similar non-playable objects.
+        if "Token" in card_types or "Emblem" in card_types or "Card" in card_types:
             return
 
         unknown_subtypes = self._get_unknown_subtypes(face, card_types)

--- a/card_utils.py
+++ b/card_utils.py
@@ -5,6 +5,7 @@ from typing import Any
 from constants import (
     NON_TRADITIONAL_BORDERS,
     NON_TRADITIONAL_LAYOUTS,
+    NON_TRADITIONAL_PROMO_TYPES,
     NON_TRADITIONAL_SET_TYPES,
 )
 
@@ -90,6 +91,7 @@ def is_traditional_card(
     non_traditional_set_types: set[str] = NON_TRADITIONAL_SET_TYPES,
     non_traditional_layouts: set[str] = NON_TRADITIONAL_LAYOUTS,
     non_traditional_borders: set[str] = NON_TRADITIONAL_BORDERS,
+    non_traditional_promo_types: set[str] = NON_TRADITIONAL_PROMO_TYPES,
 ) -> bool:
     """
     Determine if a card is considered traditional.
@@ -99,6 +101,7 @@ def is_traditional_card(
         non_traditional_set_types (set[str], optional): Set of non-traditional set types.
         non_traditional_layouts (set[str], optional): Set of non-traditional layouts.
         non_traditional_borders (set[str], optional): Set of non-traditional border colors.
+        non_traditional_promo_types (set[str], optional): Set of non-traditional promo types.
 
     Returns:
         bool: True if the card is traditional, False otherwise.
@@ -108,6 +111,8 @@ def is_traditional_card(
     if card.get("layout") in non_traditional_layouts:
         return False
     if card.get("set") == "past":
+        return False
+    if non_traditional_promo_types.intersection(card.get("promo_types", [])):
         return False
     return card.get("border_color") not in non_traditional_borders
 

--- a/constants.py
+++ b/constants.py
@@ -36,6 +36,9 @@ EXCLUDED_COLLECTOR_NUMBER_SETS = {
 NON_TRADITIONAL_SET_TYPES = {"memorabilia", "funny"}
 NON_TRADITIONAL_LAYOUTS = {"emblem", "token"}
 NON_TRADITIONAL_BORDERS = {"silver", "gold"}
+# Mystery Booster playtest cards (e.g. Orb of Origin) are mixed into the
+# otherwise-traditional mb2 set, so they must be filtered by promo type.
+NON_TRADITIONAL_PROMO_TYPES = {"playtest"}
 
 # Foil-related constants
 FOIL_PROMO_TYPES = {

--- a/tests/test_card_utils.py
+++ b/tests/test_card_utils.py
@@ -235,6 +235,17 @@ class TestIsTraditionalCard:
         }
         assert card_utils.is_traditional_card(card) is False
 
+    def test_playtest_promo_type_excluded(self):
+        """Test that Mystery Booster playtest cards are filtered."""
+        card = {
+            "set_type": "masters",
+            "layout": "normal",
+            "set": "mb2",
+            "border_color": "black",
+            "promo_types": ["playtest"],
+        }
+        assert card_utils.is_traditional_card(card) is False
+
     def test_custom_exclusion_sets(self):
         """Test that custom exclusion sets can be provided."""
         card = {

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -162,6 +162,28 @@ class TestGlobalEffects:
         assert "Land" not in key
 
 
+class TestPlaceholderTypes:
+    def test_card_placeholder_type_is_skipped(self, aggregator):
+        aggregator.process_card(make_card(type_line="Card"))
+        assert len(aggregator.maximal_types) == 0
+
+    def test_card_placeholder_face_is_skipped(self, aggregator):
+        card = make_card(
+            type_line="Card // Creature — Human",
+            card_faces=[
+                {"name": "Front", "type_line": "Card"},
+                {"name": "Back", "type_line": "Creature — Human"},
+            ],
+        )
+        aggregator.process_card(card)
+        assert list(aggregator.maximal_types) == [("Creature", "Human")]
+
+    def test_effects_aggregator_also_skips_card_placeholder(self, type_files):
+        aggregator = MaximalTypesWithEffectsAggregator(*type_files)
+        aggregator.process_card(make_card(type_line="Card"))
+        assert len(aggregator.maximal_types) == 0
+
+
 class TestNameBasedTypes:
     def test_grist_counts_as_insect_creature(self, aggregator):
         aggregator.process_card(

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -167,6 +167,10 @@ class TestPlaceholderTypes:
         aggregator.process_card(make_card(type_line="Card"))
         assert len(aggregator.maximal_types) == 0
 
+    def test_stickers_placeholder_type_is_skipped(self, aggregator):
+        aggregator.process_card(make_card(type_line="Stickers"))
+        assert len(aggregator.maximal_types) == 0
+
     def test_card_placeholder_face_is_skipped(self, aggregator):
         card = make_card(
             type_line="Card // Creature — Human",


### PR DESCRIPTION
## Summary

Three data-hygiene fixes:

- **Skip Scryfall's "Card" placeholder type** in the maximal types reports. Scryfall assigns the type line "Card" to substitute cards, art series, and similar non-playable objects, which surfaced as bogus incomparable maximal rows.
- **Skip the "Stickers" placeholder type** likewise. Both are folded into a `SKIPPED_TYPES` constant alongside the existing Token and Emblem skips.
- **Filter Mystery Booster playtest cards** (e.g. Orb of Origin, type line "Poly Artifact") via the `playtest` promo type. These are mixed into the otherwise-traditional mb2 set, so set-level filters can't catch them; Scryfall's `promo_types` containing `"playtest"` is the reliable signal (it backs their `is:playtest` operator). The check lives in `is_traditional_card` with a new `NON_TRADITIONAL_PROMO_TYPES` constant, so all reports benefit, not just the type aggregators.

## Testing

- New tests for the Card/Stickers skips (bare, per-face, and effects-aggregator inheritance) and the playtest promo type filter
- `uv run pytest` — 116 passed
- `uv run ruff format .` / `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v)_