### PR TITLE
fix: show originating face's image on maximal type rows; clarify token wording

### DIFF
--- a/aggregators/creature_type_aggregators.py
+++ b/aggregators/creature_type_aggregators.py
@@ -377,8 +377,9 @@ class TokenOnlyCreatureTypesAggregator(Aggregator):
             "Token-Only Creature Types",
             description,
             explanation=(
-                "Creature types that have only been printed on tokens, never on a non-token card"
-                " (e.g., Pentavite, Germ, Servo)."
+                "Creature types that have only appeared on printed token cards, never on a"
+                " non-token card (e.g., Pentavite, Germ, Servo). Only tokens printed as physical"
+                " token cards count — tokens that exist solely as in-game objects do not."
             ),
         )
         self.token_types: dict[str, dict[str, Any]] = {}
@@ -441,7 +442,9 @@ class RulesOnlyCreatureTypesAggregator(Aggregator):
             description,
             explanation=(
                 "Creature types defined in the comprehensive rules that have never appeared on"
-                " any card, not even as a token (e.g., Camarid, Tetravite, Caribou)."
+                " any card, not even on a printed token card (e.g., Camarid, Tetravite, Caribou)."
+                " A type whose token exists only as an in-game object, never as a printed token"
+                " card, still qualifies."
             ),
         )
         self.all_creature_types = self._load_types(all_creature_types_file)

--- a/aggregators/type_aggregators.py
+++ b/aggregators/type_aggregators.py
@@ -47,7 +47,8 @@ class MaximalPrintedTypesAggregator(Aggregator):
                 " previewed sets) are excluded until the rules are updated."
             ),
         )
-        self.maximal_types: dict[tuple[str, ...], dict[str, Any]] = {}
+        # Maps a sorted type tuple to the (face, card) pair that produced it.
+        self.maximal_types: dict[tuple[str, ...], tuple[dict[str, Any], dict[str, Any]]] = {}
         self._unknown_subtypes_seen: set[str] = set()
         self._types_field = "types"
         self.column_defs = [
@@ -122,9 +123,9 @@ class MaximalPrintedTypesAggregator(Aggregator):
         type_key = tuple(sorted(card_types))
 
         if type_key in self.maximal_types:
-            existing_card = self.maximal_types[type_key]
+            _existing_face, existing_card = self.maximal_types[type_key]
             if get_sort_key(parent_card) < get_sort_key(existing_card):
-                self.maximal_types[type_key] = parent_card
+                self.maximal_types[type_key] = (face, parent_card)
             return
 
         is_maximal = all(
@@ -139,7 +140,7 @@ class MaximalPrintedTypesAggregator(Aggregator):
             ]
             for key in keys_to_remove:
                 del self.maximal_types[key]
-            self.maximal_types[type_key] = parent_card
+            self.maximal_types[type_key] = (face, parent_card)
 
     def _get_unknown_subtypes(self, face: dict[str, Any], card_types: set[str]) -> set[str]:
         """
@@ -172,10 +173,10 @@ class MaximalPrintedTypesAggregator(Aggregator):
                 "name": card.get("name", ""),
                 "set": card.get("set", ""),
                 "releaseDate": card.get("released_at", ""),
-                **get_card_link_data(card),
+                **get_card_link_data(card, face),
             }
-            for _key, card in sorted(
-                self.maximal_types.items(), key=lambda item: get_sort_key(item[1])
+            for _key, (face, card) in sorted(
+                self.maximal_types.items(), key=lambda item: get_sort_key(item[1][1])
             )
         ]
 
@@ -203,7 +204,8 @@ class MaximalTypesWithEffectsAggregator(MaximalPrintedTypesAggregator):
         )
         self._types_field = "originalTypes"
         self.global_effects = self._define_global_effects()
-        self.maximal_types: dict[tuple[str, ...], dict[str, Any]] = {}
+        # Maps a sorted type tuple to the (face, card) pair that produced it.
+        self.maximal_types: dict[tuple[str, ...], tuple[dict[str, Any], dict[str, Any]]] = {}
         self.column_defs = [
             {"field": "originalTypes", "headerName": "Original Types", "width": 300},
             {

--- a/card_aggregator.py
+++ b/card_aggregator.py
@@ -156,7 +156,9 @@ def create_all_aggregators() -> list[Aggregator]:
         FirstLegendaryByCreatureTypeAggregator(
             description="First legendary creature for each creature subtype"
         ),
-        TokenOnlyCreatureTypesAggregator(description="Creature types that only exist on tokens"),
+        TokenOnlyCreatureTypesAggregator(
+            description="Creature types that only exist on printed token cards"
+        ),
         RulesOnlyCreatureTypesAggregator(
             all_creature_types_file=DOWNLOADED_DATA_FOLDER / ALL_CREATURE_TYPES_FILE,
             description="Creature types in the rules but never on any card",

--- a/card_utils.py
+++ b/card_utils.py
@@ -186,9 +186,17 @@ def get_card_image_uri(card: dict[str, Any], size: str = "normal") -> str:
     return ""
 
 
-def get_card_link_data(card: dict[str, Any]) -> dict[str, str]:
-    """Extract Scryfall URI and image URI from a card for use in report links."""
+def get_card_link_data(card: dict[str, Any], face: dict[str, Any] | None = None) -> dict[str, str]:
+    """
+    Extract Scryfall URI and image URI from a card for use in report links.
+
+    If a specific card face is provided, its image is preferred over the
+    card-level default (which falls back to the first face).
+    """
+    face_image_uri = ""
+    if face is not None:
+        face_image_uri = (face.get("image_uris") or {}).get("normal", "")
     return {
         "scryfall_uri": card.get("scryfall_uri", ""),
-        "image_uri": get_card_image_uri(card),
+        "image_uri": face_image_uri or get_card_image_uri(card),
     }

--- a/tests/test_type_aggregators.py
+++ b/tests/test_type_aggregators.py
@@ -207,6 +207,36 @@ class TestNameBasedTypes:
         assert list(aggregator.maximal_types) == [("Jace", "Legendary", "Planeswalker")]
 
 
+class TestFaceImages:
+    def test_maximal_back_face_uses_its_own_image(self, aggregator):
+        # A row produced by the back face of a double-faced card must show
+        # that face's image, not the front face's.
+        card = make_card(
+            name="Front Face // Back Face",
+            type_line="Creature — Human // Creature — Human Wizard",
+            card_faces=[
+                {
+                    "name": "Front Face",
+                    "type_line": "Creature — Human",
+                    "image_uris": {"normal": "front.jpg"},
+                },
+                {
+                    "name": "Back Face",
+                    "type_line": "Creature — Human Wizard",
+                    "image_uris": {"normal": "back.jpg"},
+                },
+            ],
+        )
+        aggregator.process_card(card)
+        (row,) = aggregator.get_sorted_data()
+        assert row["image_uri"] == "back.jpg"
+
+    def test_single_faced_card_image_is_unchanged(self, aggregator):
+        aggregator.process_card(make_card(image_uris={"normal": "card.jpg"}))
+        (row,) = aggregator.get_sorted_data()
+        assert row["image_uri"] == "card.jpg"
+
+
 class TestMaximality:
     def test_subset_is_replaced_by_superset(self, aggregator):
         aggregator.process_card(make_card(type_line="Creature — Human"))


### PR DESCRIPTION
## Summary

- **Fix hover images on face-derived maximal type rows.** Rows produced by the back face of a double-faced card were showing the front face's image (e.g. The Soul Stone's row displayed The Terminus of Return, since `get_card_image_uri` always falls back to the first face). `maximal_types` now stores the `(face, card)` pair that produced each row, and `get_card_link_data` takes an optional face whose image is preferred, falling back to the old card-level behavior. Applies to both maximal types reports via inheritance; single-faced cards are unchanged.
- **Clarify token wording in the creature type reports.** The Token-Only and Rules-Only descriptions and explanations now state that they mean printed token cards in Scryfall's data, not tokens as in-game objects.

## Testing

- New tests: a double-faced card whose maximal back face must use its own image, and a single-faced card keeping the card-level image
- `uv run pytest` — 118 passed
- `uv run ruff format .` / `uv run ruff check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v)_