### PR TITLE
data: add Poxes supercycle and fix Elder Titans and Forces comments

### DIFF
--- a/data/manual/supercycles.yaml
+++ b/data/manual/supercycles.yaml
@@ -172,7 +172,6 @@ supercycles:
       - Phlage, Titan of Fire's Fury # Red/White
       - Kroxa, Titan of Death's Hunger # Black/Red
       - Uro, Titan of Nature's Wrath # Blue/Green
-      - Skotha, Titan of Eternal Dark
 
   - name: Tripled Creatures
     finished: false # Creatures that are three of the same thing

--- a/data/manual/supercycles.yaml
+++ b/data/manual/supercycles.yaml
@@ -133,7 +133,7 @@ supercycles:
       - Foratog
 
   - name: Forces
-    finished: true # Creatures with "Force" in name from Time Spiral
+    finished: true # 7/7 Elementals with upkeep triggers, from Commander decks plus Tempest's Verdant Force
     cards:
       - Celestial Force
       - Tidal Force
@@ -167,11 +167,12 @@ supercycles:
       - Western Paladin
 
   - name: Elder Titans
-    finished: false # Needs a white titan to complete
+    finished: false # More two-color titans may still be printed
     cards:
       - Phlage, Titan of Fire's Fury # Red/White
       - Kroxa, Titan of Death's Hunger # Black/Red
       - Uro, Titan of Nature's Wrath # Blue/Green
+      - Skotha, Titan of Eternal Dark
 
   - name: Tripled Creatures
     finished: false # Creatures that are three of the same thing
@@ -446,3 +447,10 @@ supercycles:
       - Thirst for Meaning
       - Thirst for Discovery
       - Thirst for Identity
+
+  - name: Poxes
+    finished: false # All-black-pip sorceries with symmetric life/discard/sacrifice effects
+    cards:
+      - Pox
+      - Smallpox
+      - Pox Plague


### PR DESCRIPTION
## Summary

Supercycle config updates from an audit against the mtg.wiki Mega cycle page:

- **Add the Poxes supercycle** — Pox, Smallpox, Pox Plague (all-black-pip sorceries with symmetric life/discard/sacrifice effects), unfinished.
- **Fix the Elder Titans comment** — "needs a white titan" replaced with "more two-color titans may still be printed." (Skotha, Titan of Eternal Dark was briefly added from the wiki listing, then removed — it's a lore character with no printed card.)
- **Fix the Forces comment** — they're 7/7 Elementals with upkeep triggers from Commander decks plus Tempest's Verdant Force, not Time Spiral cards.

## Testing

- YAML validated by loading; `uv run pytest` — 118 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6PEPMHeDVzwM7iWXjCB1v)_