### PR TITLE
Fix nightly download for Scryfall's JSONL-only bulk data format

### DIFF
--- a/.github/workflows/publish_html.yml
+++ b/.github/workflows/publish_html.yml
@@ -71,5 +71,5 @@ jobs:
         uses: actions/upload-artifact@v7.0.0
         with:
           name: card-data
-          path: ${{ env.DOWNLOAD_FOLDER }}/*.json
+          path: ${{ env.DOWNLOAD_FOLDER }}/*.jsonl.gz
           retention-days: 7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ uv run python card_aggregator.py all             # Full workflow: download → t
 
 ## Data Flow
 
-1. **Download** — Fetches bulk data from Scryfall API, saves to `data/downloads/`
-2. **Processing** — Streams JSON via `ijson`, calls `process_card()` on each aggregator
+1. **Download** — Fetches bulk data from Scryfall API (gzipped JSONL via `jsonl_download_uri`), saves to `data/downloads/`
+2. **Processing** — Streams cards via `iter_cards()` (gzipped JSONL line-by-line; legacy `.json` arrays via `ijson`), calls `process_card()` on each aggregator
 3. **Output** — Generates HTML via Jinja2, writes to `data/output/`
 4. **Deployment** — GitHub Actions runs daily, deploys to GitHub Pages
 
@@ -119,7 +119,8 @@ Package management via **uv**.
 2. **Collector Number Sorting** — May contain letters (e.g., "123a"); `get_sort_key()` strips non-digits.
 3. **Date Handling** — Cards without release dates get `datetime.max.date()` for sorting.
 4. **Supercycle Sorting** — Sort by `days` field, not the formatted time string (bug fix: a03c957).
-5. **Memory Efficiency** — Use `ijson` for streaming large JSON files.
+5. **Memory Efficiency** — Stream card data instead of loading it whole: gzipped JSONL is read line-by-line, legacy JSON arrays via `ijson`.
+6. **Scryfall Bulk Format** — As of July 2026, Scryfall only offers bulk data as gzipped JSONL (`jsonl_download_uri` / `compressed_size`); the old `download_uri` / `size` fields are gone.
 
 ## Before Committing
 

--- a/card_aggregator.py
+++ b/card_aggregator.py
@@ -1,6 +1,8 @@
+import gzip
 import http.server
 import json
 import os
+import re
 import socketserver
 import threading
 import webbrowser
@@ -53,7 +55,6 @@ MANUAL_DATA_FOLDER = DATA_FOLDER / "manual"
 OUTPUT_DATA_FOLDER = DATA_FOLDER / "output"
 ALL_CREATURE_TYPES_FILE = "all_creature_types.txt"
 ALL_LAND_TYPES_FILE = "all_land_types.txt"
-DEFAULT_INPUT_FILE = DOWNLOADED_DATA_FOLDER / "default-cards.json"
 DEFAULT_OUTPUT_FOLDER = OUTPUT_DATA_FOLDER
 
 app = typer.Typer(
@@ -290,8 +291,17 @@ def download():
         logger.error("Could not find default_cards file in bulk data list")
         raise typer.Exit(1) from None
 
-    download_url = default_cards_file["download_uri"]
-    file_name = f"default-cards-{default_cards_file['updated_at'][:10]}.json"
+    # Scryfall retired the plain-JSON download_uri in July 2026; bulk data is
+    # now only offered as gzipped JSONL via jsonl_download_uri.
+    try:
+        download_url = default_cards_file["jsonl_download_uri"]
+        total_size = int(default_cards_file["compressed_size"])
+    except KeyError as e:
+        logger.error("Bulk data entry is missing expected field: {}", e)
+        logger.warning("The Scryfall API response format may have changed.")
+        raise typer.Exit(1) from None
+
+    file_name = f"default-cards-{default_cards_file['updated_at'][:10]}.jsonl.gz"
     DOWNLOADED_DATA_FOLDER.mkdir(parents=True, exist_ok=True)
     file_path = DOWNLOADED_DATA_FOLDER / file_name
 
@@ -314,9 +324,8 @@ def download():
         logger.error("Request error while downloading file: {}", e)
         raise typer.Exit(1) from None
 
-    total_size = int(default_cards_file["size"])
     logger.info(
-        "Downloading {} ({:.1f} MB)...",
+        "Downloading {} ({:.1f} MB compressed)...",
         default_cards_file["name"],
         total_size / (1024 * 1024),
     )
@@ -417,12 +426,34 @@ def find_latest_default_cards(data_folder: Path) -> Path | None:
     Returns:
         Optional[Path]: The path to the latest "default-cards" file, or None if not found.
     """
-    default_cards_files = list(data_folder.glob("default-cards-*.json"))
-    return (
-        max(default_cards_files, key=lambda f: f.stem.split("-")[-1])
-        if default_cards_files
-        else None
-    )
+    default_cards_files = [
+        file
+        for pattern in ("default-cards-*.json", "default-cards-*.jsonl.gz")
+        for file in data_folder.glob(pattern)
+    ]
+
+    def date_key(file: Path) -> str:
+        match = re.search(r"\d{4}-\d{2}-\d{2}", file.name)
+        return match.group() if match else ""
+
+    return max(default_cards_files, key=date_key, default=None)
+
+
+def iter_cards(input_file: Path):
+    """
+    Stream card objects from a Scryfall bulk data file.
+
+    Supports gzipped JSONL (.jsonl.gz, the current Scryfall format) and
+    legacy JSON arrays (.json).
+    """
+    if input_file.name.endswith(".jsonl.gz"):
+        with gzip.open(input_file, "rt", encoding="utf-8") as file:
+            for line in file:
+                if line.strip():
+                    yield json.loads(line)
+    else:
+        with input_file.open("rb") as file:
+            yield from ijson.items(file, "item")
 
 
 def generate_nav_links(aggregators: list[Aggregator]) -> list[dict[str, str]]:
@@ -499,17 +530,16 @@ def run_internal(
     logger.info("Processing cards through {} aggregators...", len(aggregators))
     error_count = 0
     max_errors = 100
-    with input_file.open("rb") as file:
-        for card in ijson.items(file, "item"):
-            for aggregator in aggregators:
-                try:
-                    aggregator.process_card(card)
-                except Exception as e:
-                    error_count += 1
-                    logger.error("Error processing card {}: {}", card.get("name", "Unknown"), e)
-                    if error_count >= max_errors:
-                        logger.critical("Too many processing errors ({}), aborting", error_count)
-                        raise typer.Exit(1) from e
+    for card in iter_cards(input_file):
+        for aggregator in aggregators:
+            try:
+                aggregator.process_card(card)
+            except Exception as e:
+                error_count += 1
+                logger.error("Error processing card {}: {}", card.get("name", "Unknown"), e)
+                if error_count >= max_errors:
+                    logger.critical("Too many processing errors ({}), aborting", error_count)
+                    raise typer.Exit(1) from e
     if error_count > 0:
         logger.warning("Completed with {} processing error(s)", error_count)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,8 +135,8 @@ def mock_scryfall_response():
                 "updated_at": datetime.now().isoformat(),
                 "name": "Default Cards",
                 "description": "All cards in the default format",
-                "download_uri": "https://example.com/cards.json",
-                "size": 100000000,
+                "jsonl_download_uri": "https://example.com/cards.jsonl.gz",
+                "compressed_size": 100000000,
             }
         ],
     }

--- a/tests/test_card_aggregator.py
+++ b/tests/test_card_aggregator.py
@@ -1,0 +1,80 @@
+"""Tests for card_aggregator download and data-file handling."""
+
+import gzip
+import json
+
+import responses
+
+from card_aggregator import download, find_latest_default_cards, iter_cards
+
+
+class TestIterCards:
+    def test_reads_gzipped_jsonl(self, temp_dir, sample_cards_list):
+        file_path = temp_dir / "default-cards-2026-07-29.jsonl.gz"
+        with gzip.open(file_path, "wt", encoding="utf-8") as f:
+            for card in sample_cards_list:
+                f.write(json.dumps(card) + "\n")
+
+        cards = list(iter_cards(file_path))
+        assert cards == sample_cards_list
+
+    def test_skips_blank_lines_in_jsonl(self, temp_dir, sample_card):
+        file_path = temp_dir / "default-cards-2026-07-29.jsonl.gz"
+        with gzip.open(file_path, "wt", encoding="utf-8") as f:
+            f.write(json.dumps(sample_card) + "\n\n")
+
+        cards = list(iter_cards(file_path))
+        assert cards == [sample_card]
+
+    def test_reads_legacy_json_array(self, temp_dir, sample_cards_list):
+        file_path = temp_dir / "default-cards-2026-07-01.json"
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(sample_cards_list, f)
+
+        cards = list(iter_cards(file_path))
+        assert [card["name"] for card in cards] == [card["name"] for card in sample_cards_list]
+
+
+class TestFindLatestDefaultCards:
+    def test_returns_none_when_empty(self, temp_dir):
+        assert find_latest_default_cards(temp_dir) is None
+
+    def test_prefers_newest_date_across_formats(self, temp_dir):
+        (temp_dir / "default-cards-2026-07-19.json").touch()
+        (temp_dir / "default-cards-2026-07-29.jsonl.gz").touch()
+
+        latest = find_latest_default_cards(temp_dir)
+        assert latest is not None
+        assert latest.name == "default-cards-2026-07-29.jsonl.gz"
+
+    def test_compares_dates_across_months(self, temp_dir):
+        (temp_dir / "default-cards-2026-06-30.jsonl.gz").touch()
+        (temp_dir / "default-cards-2026-07-01.jsonl.gz").touch()
+
+        latest = find_latest_default_cards(temp_dir)
+        assert latest is not None
+        assert latest.name == "default-cards-2026-07-01.jsonl.gz"
+
+
+class TestDownload:
+    @responses.activate
+    def test_downloads_jsonl_gz(self, tmp_path, monkeypatch, mock_scryfall_response):
+        monkeypatch.setattr("card_aggregator.DOWNLOADED_DATA_FOLDER", tmp_path)
+
+        file_body = gzip.compress(b'{"name": "Lightning Bolt"}\n')
+        entry = mock_scryfall_response["data"][0]
+        entry["compressed_size"] = len(file_body)
+        entry["updated_at"] = "2026-07-29T09:08:26.918+00:00"
+
+        responses.add(
+            responses.GET,
+            "https://api.scryfall.com/bulk-data",
+            json=mock_scryfall_response,
+        )
+        responses.add(responses.GET, entry["jsonl_download_uri"], body=file_body)
+
+        file_path = download()
+
+        assert file_path == tmp_path / "default-cards-2026-07-29.jsonl.gz"
+        assert file_path.read_bytes() == file_body
+        assert list(iter_cards(file_path)) == [{"name": "Lightning Bolt"}]


### PR DESCRIPTION
## Summary

The scheduled "Publish HTML" run on 2026-07-29 failed with `KeyError: 'download_uri'`. Scryfall retired plain-JSON bulk data downloads in July 2026 ([announcement](https://scryfall.com/blog/two-new-ways-to-sync-scryfall-data-236)): bulk data entries now only expose `jsonl_download_uri` (a gzipped JSONL file) and `compressed_size` — the old `download_uri` and `size` fields are gone.

## Changes

- **`download`**: fetch the `.jsonl.gz` file via `jsonl_download_uri`, verify the byte count against `compressed_size`, and fail with a clear log message if the schema changes again
- **`iter_cards()`** (new): stream gzipped JSONL line-by-line; legacy `.json` array files still stream via `ijson`
- **`find_latest_default_cards`**: match both file formats, and compare full `YYYY-MM-DD` dates — the old sort key only compared the day-of-month, which would pick the wrong file across month boundaries
- **Workflow**: card-data artifact glob updated to `*.jsonl.gz`
- **Tests**: fixture updated to the new API schema; new `tests/test_card_aggregator.py` covers JSONL streaming, legacy JSON, latest-file selection, and a mocked end-to-end download
- **Docs**: CLAUDE.md data-flow and quirks updated

## Testing

- All 125 tests pass (`uv run pytest`)
- `ruff format` / `ruff check` clean
- Live download not exercised (sandbox blocks scryfall.com); the next scheduled run is the end-to-end confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VKHbdJd6wtdqVo8zRNP3q

---
_Generated by [Claude Code](https://claude.ai/code/session_013VKHbdJd6wtdqVo8zRNP3q)_