### PR TITLE
Suppress AG Grid cell focus ring on touch devices

### DIFF
--- a/templates/base_template.html
+++ b/templates/base_template.html
@@ -445,11 +445,17 @@
       // Initialize grid with loading state
       const columnDefs = {{ column_defs | tojson }};
 
+      // On touch devices, tapping a cell draws a focus ring that serves no
+      // purpose (there's no keyboard navigation); suppress it so taps only
+      // interact with links. Matches the touch media query used in the CSS.
+      const isTouchDevice = window.matchMedia('(hover: none) and (pointer: coarse)').matches;
+
       const gridOptions = {
         theme: "legacy",
         columnDefs: columnDefs,
         rowData: null,
         loading: true,
+        suppressCellFocus: isTouchDevice,
         defaultColDef: {
           sortable: true,
           filter: true,


### PR DESCRIPTION
Tapping a grid cell on mobile drew AG Grid's cell focus outline, which serves no purpose on touch devices since there's no keyboard navigation — it just looked like a pointless "selection."

This enables AG Grid's `suppressCellFocus` option when the device matches the same `(hover: none) and (pointer: coarse)` media query the template already uses for touch styling. Desktop keeps normal cell focus and keyboard navigation; card links in cells remain tappable as ordinary anchors.

- All 125 tests pass; ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E8wV5tpzyU2xQKNm8rWDtU

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8wV5tpzyU2xQKNm8rWDtU)_