### PR TITLE
Add Tarot Major Arcana supercycle

### DIFF
--- a/data/manual/supercycles.yaml
+++ b/data/manual/supercycles.yaml
@@ -453,3 +453,10 @@ supercycles:
       - Pox
       - Smallpox
       - Pox Plague
+
+  - name: Tarot Major Arcana
+    finished: false # Legendary creatures referencing tarot major arcana
+    cards:
+      - Flubs, the Fool
+      - Homer, the Hermit
+      - Massimo, the Magician


### PR DESCRIPTION
Adds a new supercycle to `data/manual/supercycles.yaml` tracking the legendary creatures that reference tarot major arcana:

- Flubs, the Fool
- Homer, the Hermit
- Massimo, the Magician

Marked `finished: false` since the tarot major arcana has many more figures that could still receive cards.

All 125 tests pass; ruff format and check are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFVkKZeSg8wdymdRf6b1Ka

---
_Generated by [Claude Code](https://claude.ai/code/session_01UFVkKZeSg8wdymdRf6b1Ka)_