### PR TITLE
Add Craterhoof Finishers unfinished supercycle

### DIFF
--- a/data/manual/supercycles.yaml
+++ b/data/manual/supercycles.yaml
@@ -460,3 +460,10 @@ supercycles:
       - Flubs, the Fool
       - Homer, the Hermit
       - Massimo, the Magician
+
+  - name: Craterhoof Finishers
+    finished: false # Mythic creatures that pump your team by X and grant evasion on enter
+    cards:
+      - Craterhoof Behemoth # Green - trample, X is creatures you control
+      - Moonshaker Cavalry # White - flying, X is creatures you control
+      - Craterclaw Colossus # Red - trample, X is artifacts you control


### PR DESCRIPTION
Adds a new unfinished supercycle to `data/manual/supercycles.yaml` tracking mythic creatures that pump your team by X and grant evasion when they enter:

| Card | Set | Effect |
| --- | --- | --- |
| Craterhoof Behemoth | Avacyn Restored | Green — trample, X is creatures you control |
| Moonshaker Cavalry | Wilds of Eldraine | White — flying, X is creatures you control |
| Craterclaw Colossus | Reality Fracture | Red — trample, X is artifacts you control |

Card names were verified against Scryfall (the requested "Moonshaker Cavalary" is spelled **Cavalry**).

Note: Craterclaw Colossus releases 2026-10-02, so until then it won't be present in Scryfall bulk data. The aggregator logs a warning for the missing card and computes the cycle from the two available ones — the same behavior as any not-yet-released entry, and it resolves itself on release.

`uv run pytest` (125 passed), `uv run ruff format --check .`, and `uv run ruff check .` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWeSre5pxHe1SanY7cfFME)_